### PR TITLE
Memory leak fixes in basedclient.cpp & bounds checking for read_bytes_from_string

### DIFF
--- a/packages/cpp-client/src/basedclient.cpp
+++ b/packages/cpp-client/src/basedclient.cpp
@@ -518,7 +518,7 @@ void BasedClient::on_message(std::string message) {
             if (error.find("observableId") != error.end()) {
                 // destroy observable
                 auto obs_id = error.at("observableId");
-
+                delete m_observe_requests.at(obs_id);
                 m_observe_requests.erase(obs_id);
 
                 if (m_observe_subs.find(obs_id) != m_observe_subs.end()) {
@@ -527,7 +527,7 @@ void BasedClient::on_message(std::string message) {
                             auto fn = m_sub_callback.at(sub_id);
                             fn("", 0, payload.c_str(), sub_id);
                         }
-                        m_observe_subs.erase(sub_id);
+                        m_observe_subs.erase(obs_id);
                         m_sub_to_obs.erase(sub_id);
                     }
                 }

--- a/packages/cpp-client/src/utility.cpp
+++ b/packages/cpp-client/src/utility.cpp
@@ -331,12 +331,17 @@ int32_t Utility::read_header(std::string buff) {
     return res;
 }
 
-int64_t Utility::read_bytes_from_string(std::string& buff, int start, int len) {
-    char const* data = buff.data();
-    int32_t res = 0;
-    size_t s = len - 1 + start;  // len - 1 + start;
-    for (int i = s; i >= start; i--) {
-        res = res * 256 + (uint8_t)data[i];
+uint64_t Utility::read_bytes_from_string(std::string& buff, int start, int len) {
+    if (start < 0 || len < 0 || start + len > static_cast<int>(buff.size())) {
+        throw std::out_of_range("read_bytes_from_string: Out of bounds access");
     }
+
+    char const* data = buff.data();
+    uint64_t res = 0;
+
+    for (int i = 0; i < len; i++) {
+        res |= (static_cast<uint64_t>((uint8_t)data[start + i])) << (8 * i);
+    }
+
     return res;
 }


### PR DESCRIPTION
- Fixed a memory leak in basedclient.cpp within on_message() ERROR_DATA case, where the observable itself was not delete(d).
- Fixed an incorrect erasure in the same case on m_observe_subs which was using the sub_id instead of the obs_id.
- Improved the read_bytes_from_string function by including bounds checking and using bitwise shifts & ORs for the calculation so that it's more readable. Also made sure to use uint64 to match the method signature's return type.